### PR TITLE
Add DOC conversion and docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ npm install
 npm start
 ```
 
+### Required packages
+
+The server relies on the following npm packages:
+
+```
+- express
+- multer
+- morgan
+- cors
+- mammoth
+- libreoffice-convert
+```
+
+In addition, the `libreoffice-convert` package requires a local installation of
+LibreOffice to perform the `.doc` to `.docx` conversion.
+
 ## Example usage
 
 Upload one or more `.doc` or `.docx` files using the field name `file`. An optional `chunk` query parameter splits the returned text into chunks of the given size.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "express": "*",
     "multer": "*",
     "mammoth": "*",
-    "textract": "*",
+    "libreoffice-convert": "*",
     "morgan": "*"
   }
 }


### PR DESCRIPTION
## Summary
- convert `.doc` files to `.docx` using `libreoffice-convert` before extracting text
- document required dependencies in the README
- include `libreoffice-convert` in `package.json`

## Testing
- No tests run due to instructions

------
https://chatgpt.com/codex/tasks/task_b_6841392708408331bb5a4e6dafcafbab