### PR TITLE
Add LibreOffice guidance and test framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ npm install
 npm start
 ```
 
+Run tests with coverage using:
+
+```bash
+npm test
+```
+
 ### Required packages
 
 The server relies on the following npm packages:
@@ -25,12 +31,27 @@ The server relies on the following npm packages:
 In addition, the `libreoffice-convert` package requires a local installation of
 LibreOffice to perform the `.doc` to `.docx` conversion.
 
-## Windows
+### LibreOffice on Linux
+
+Install LibreOffice from your package manager. On Debian/Ubuntu run:
+
+```bash
+sudo apt-get update && sudo apt-get install libreoffice
+```
+
+Ensure the `soffice` binary is available in your `PATH` so that
+`libreoffice-convert` can invoke it.
+
+When deploying with [Nixpacks](https://nixpacks.com), the provided
+`nixpacks.toml` installs LibreOffice automatically.
+
+### Windows
 
 Windows users can download LibreOffice from the
 [official installer](https://www.libreoffice.org/download/download/).
 After installation, add the directory containing the `soffice` binary to your
 `PATH` environment variable so that `libreoffice-convert` can locate it.
+
 
 ## Example usage
 
@@ -43,3 +64,7 @@ curl -F "file=@sample.docx" "http://localhost:8000/extract"
 # Multiple uploads
 curl -F "file=@sample.docx" -F "file=@sample2.doc" "http://localhost:8000/extract?chunk=1000"
 ```
+
+## Environment variables
+
+`MAX_CONCURRENT_UPLOADS` sets the number of simultaneous uploads the server will process at once. It defaults to `5` if unspecified.

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,0 +1,8 @@
+import { normalizeText } from '../index.js';
+
+describe('normalizeText', () => {
+  test('collapses whitespace', () => {
+    const result = normalizeText('foo   bar\n\nbaz');
+    expect(result).toBe('foo bar baz');
+  });
+});

--- a/index.js
+++ b/index.js
@@ -46,8 +46,15 @@ async function extractText(file) {
     const input = await fs.readFile(file.path);
     const docxBuffer = await new Promise((resolve, reject) => {
       libre.convert(input, '.docx', undefined, (err, done) => {
-        if (err) reject(err);
-        else resolve(done);
+        if (err) {
+          if (err.code === 'ENOENT' || /spawn/.test(err.message)) {
+            reject(new Error('LibreOffice not found. Is it installed and in PATH?'));
+          } else {
+            reject(err);
+          }
+        } else {
+          resolve(done);
+        }
       });
     });
     const result = await mammoth.extractRawText({ buffer: docxBuffer });
@@ -105,3 +112,5 @@ const PORT = process.env.PORT || 8000;
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });
+
+export { normalizeText };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+export default {
+  testEnvironment: 'node',
+  collectCoverage: true,
+  coverageDirectory: 'coverage'
+};

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,2 @@
+[phases.setup]
+aptPkgs = ["libreoffice"]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": ".",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest --coverage",
     "start": "node index.js"
   },
   "keywords": [],
@@ -18,5 +18,8 @@
     "mammoth": "*",
     "libreoffice-convert": "*",
     "morgan": "*"
+  },
+  "devDependencies": {
+    "jest": "*"
   }
 }


### PR DESCRIPTION
## Summary
- document LibreOffice installation with Linux and Windows instructions
- add environment variable description and mention Nixpacks support
- add jest test framework with coverage
- catch missing LibreOffice errors when converting
- create Nixpacks configuration for installing LibreOffice
- export helper for testing and provide basic test

## Testing
- Skipped running tests because the environment lacks `jest`

------
https://chatgpt.com/codex/tasks/task_b_6841401fa7508331aeb555d965e861cd