### PR TITLE
Use system temp dir for uploads

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ import morgan from 'morgan';
 import cors from 'cors';
 import { promises as fs } from 'fs';
 import path from 'path';
+import os from 'os';
 
 const MAX_CONCURRENT_UPLOADS = parseInt(process.env.MAX_CONCURRENT_UPLOADS, 10) || 5;
 let activeUploads = 0;
@@ -15,7 +16,7 @@ let activeUploads = 0;
 const allowedExtensions = ['.doc', '.docx'];
 
 const upload = multer({
-  dest: '/tmp',
+  dest: os.tmpdir(),
   limits: { fileSize: 20 * 1024 * 1024 },
   fileFilter: (req, file, cb) => {
     const ext = path.extname(file.originalname).toLowerCase();


### PR DESCRIPTION
## Summary
- import `os` in `index.js`
- store uploaded files in Node's temp directory with `os.tmpdir()`

## Testing
- No tests run due to offline environment

------
https://chatgpt.com/codex/tasks/task_b_68414212969c83318ac9504b0bea5fb5